### PR TITLE
fix(questions): fix get questions missing isCorrect field

### DIFF
--- a/BE_BudgetMate/src/main/java/com/exe201/project/dto/response/answer/AnswerResponse.java
+++ b/BE_BudgetMate/src/main/java/com/exe201/project/dto/response/answer/AnswerResponse.java
@@ -9,6 +9,7 @@ public record AnswerResponse(
         UUID id,
         String answerText,
         Integer displayOrder,
+        Boolean isCorrect,
         Boolean isActive
 ) {
 }

--- a/BE_BudgetMate/src/main/java/com/exe201/project/mapper/QuestionMapper.java
+++ b/BE_BudgetMate/src/main/java/com/exe201/project/mapper/QuestionMapper.java
@@ -25,6 +25,7 @@ public class QuestionMapper {
                 .id(answer.getId())
                 .answerText(answer.getAnswerText())
                 .displayOrder(answer.getDisplayOrder())
+                .isCorrect(answer.getIsCorrect())
                 .isActive(answer.getIsActive())
                 .build();
     }


### PR DESCRIPTION
This pull request introduces a new field, `isCorrect`, to the `AnswerResponse` DTO and updates the `QuestionMapper` class to include this field when mapping `Answer` entities to `AnswerResponse` objects.

DTO changes:

* [`BE_BudgetMate/src/main/java/com/exe201/project/dto/response/answer/AnswerResponse.java`](diffhunk://#diff-1d9c7876eb3e198e9df64f15cad65aab672370522b7da0fd916b4ecd8c5033f0R12): Added a new `Boolean isCorrect` field to the `AnswerResponse` record to represent whether an answer is correct.

Mapper updates:

* [`BE_BudgetMate/src/main/java/com/exe201/project/mapper/QuestionMapper.java`](diffhunk://#diff-b94341ffdf5c16b15347de234d53909af4c361ac617f929920f2460bb34703d5R28): Updated the `toAnswerResponse` method to map the `isCorrect` field from the `Answer` entity to the `AnswerResponse` DTO.